### PR TITLE
Fixed duplicate `markdownx-editor` class on widget

### DIFF
--- a/markdownx/widgets.py
+++ b/markdownx/widgets.py
@@ -61,7 +61,8 @@ class MarkdownxWidget(forms.Textarea):
         :rtype: dict
         """
         if 'class' in attrs.keys():
-            attrs['class'] += ' markdownx-editor'
+            if 'markdownx-editor' not in attrs['class']:
+                attrs['class'] += ' markdownx-editor'
         else:
             attrs.update({
                 'class': 'markdownx-editor'


### PR DESCRIPTION
Prevents duplication of ``markdownx-editor`` html class